### PR TITLE
feat(faker): update Supabase env/images and bump faker to 1.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x' # SDK que suporta netstandard2.1
+        dotnet-version: '10.0.x' # SDK que suporta netstandard2.1
     
     - name: Restore dependencies
       run: dotnet restore ./src/Supabase.sln

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
         
     - name: Restore dependencies
       working-directory: ./src

--- a/src/Supabase.Authentication.Tests/Auth/SupabaseAuthTests.cs
+++ b/src/Supabase.Authentication.Tests/Auth/SupabaseAuthTests.cs
@@ -56,7 +56,7 @@ public class SupabaseAuthTests : IClassFixture<TestFixture>
 
         user.UserMetadata.Should().NotBeNull();
         user.UserMetadata.Email.Should().Be(email);
-        user.UserMetadata.EmailVerified.Should().BeFalse();
+        user.UserMetadata.EmailVerified.Should().BeTrue();
         user.UserMetadata.PhoneVerified.Should().BeFalse();
         user.UserMetadata.Sub.Should().NotBeNullOrEmpty();
 
@@ -104,7 +104,7 @@ public class SupabaseAuthTests : IClassFixture<TestFixture>
         user.UserMetadata.Address.Should().BeEquivalentTo(address);
         user.UserMetadata.Should().NotBeNull();
         user.UserMetadata.Email.Should().Be(email);
-        user.UserMetadata.EmailVerified.Should().BeFalse();
+        user.UserMetadata.EmailVerified.Should().BeTrue();
         user.UserMetadata.PhoneVerified.Should().BeFalse();
         user.UserMetadata.Sub.Should().NotBeNullOrEmpty();
 
@@ -276,7 +276,7 @@ public class SupabaseAuthTests : IClassFixture<TestFixture>
         user.UserMetadata.Address.Should().BeEquivalentTo(address);
         user.UserMetadata.Should().NotBeNull();
         user.UserMetadata.Email.Should().Be(email);
-        user.UserMetadata.EmailVerified.Should().BeFalse();
+        user.UserMetadata.EmailVerified.Should().BeTrue();
         user.UserMetadata.PhoneVerified.Should().BeFalse();
         user.UserMetadata.Sub.Should().NotBeNullOrEmpty();
 

--- a/src/Supabase.Authentication.Tests/Supabase.Authentication.Tests.csproj
+++ b/src/Supabase.Authentication.Tests/Supabase.Authentication.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Supabase.Authentication/Supabase.Authentication.csproj
+++ b/src/Supabase.Authentication/Supabase.Authentication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>net9.0</TargetFramework>
+      <TargetFramework>net10.0</TargetFramework>
       <ImplicitUsings>enable</ImplicitUsings>
       <Nullable>enable</Nullable>
       <Authors>Hitmasu</Authors>

--- a/src/Supabase.Faker/Supabase.Faker.csproj
+++ b/src/Supabase.Faker/Supabase.Faker.csproj
@@ -11,7 +11,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageId>supabase-dotnet-faker</PackageId>
-        <Version>1.1.0</Version>
+        <Version>1.2.0</Version>
         <RepositoryType>Git</RepositoryType>
         <PackageTags>Supabase</PackageTags>
     </PropertyGroup>

--- a/src/Supabase.Faker/Supabase.Faker.csproj
+++ b/src/Supabase.Faker/Supabase.Faker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Authors>Hitmasu</Authors>

--- a/src/Supabase.Faker/Supabase/.env
+++ b/src/Supabase.Faker/Supabase/.env
@@ -78,8 +78,8 @@ ENABLE_EMAIL_AUTOCONFIRM=true
 SMTP_ADMIN_EMAIL=admin@example.com
 SMTP_HOST=supabase-mail
 SMTP_PORT=2500
-SMTP_USER=fake_mail_user
-SMTP_PASS=fake_mail_password
+SMTP_USER=
+SMTP_PASS=
 SMTP_SENDER_NAME=fake_sender
 ENABLE_ANONYMOUS_USERS=false
 

--- a/src/Supabase.Faker/Supabase/.env
+++ b/src/Supabase.Faker/Supabase/.env
@@ -9,6 +9,10 @@ ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKIC
 SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
 DASHBOARD_USERNAME=supabase
 DASHBOARD_PASSWORD=this_password_is_insecure_and_should_be_updated
+SECRET_KEY_BASE=UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq
+VAULT_ENC_KEY=your-32-character-encryption-key
+PG_META_CRYPTO_KEY=your-encryption-key-32-chars-min
+
 
 ############
 # Database - You can change these to any PostgreSQL database that has logical replication enabled.
@@ -19,13 +23,21 @@ POSTGRES_DB=postgres
 POSTGRES_PORT=5432
 # default user is postgres
 
+
 ############
 # Supavisor -- Database pooler
 ############
+# Port Supavisor listens on for transaction pooling connections
 POOLER_PROXY_PORT_TRANSACTION=6543
+# Maximum number of PostgreSQL connections Supavisor opens per pool
 POOLER_DEFAULT_POOL_SIZE=20
+# Maximum number of client connections Supavisor accepts per pool
 POOLER_MAX_CLIENT_CONN=100
+# Unique tenant identifier
 POOLER_TENANT_ID=your-tenant-id
+# Pool size for internal metadata storage used by Supavisor
+# This is separate from client connections and used only by Supavisor itself
+POOLER_DB_POOL_SIZE=5
 
 
 ############
@@ -65,9 +77,9 @@ ENABLE_EMAIL_SIGNUP=true
 ENABLE_EMAIL_AUTOCONFIRM=true
 SMTP_ADMIN_EMAIL=admin@example.com
 SMTP_HOST=supabase-mail
-SMTP_PORT=8025
-SMTP_USER=
-SMTP_PASS=
+SMTP_PORT=2500
+SMTP_USER=fake_mail_user
+SMTP_PASS=fake_mail_password
 SMTP_SENDER_NAME=fake_sender
 ENABLE_ANONYMOUS_USERS=false
 
@@ -83,7 +95,6 @@ ENABLE_PHONE_AUTOCONFIRM=true
 STUDIO_DEFAULT_ORGANIZATION=Default Organization
 STUDIO_DEFAULT_PROJECT=Default Project
 
-STUDIO_PORT=3000
 # replace if you intend to use Studio outside of localhost
 SUPABASE_PUBLIC_URL=http://localhost:8000
 
@@ -93,21 +104,23 @@ IMGPROXY_ENABLE_WEBP_DETECTION=true
 # Add your OpenAI API key to enable SQL Editor Assistant
 OPENAI_API_KEY=
 
+
 ############
 # Functions - Configuration for Functions
 ############
 # NOTE: VERIFY_JWT applies to all functions. Per-function VERIFY_JWT is not supported yet.
 FUNCTIONS_VERIFY_JWT=false
 
+
 ############
-# Logs - Configuration for Logflare
+# Logs - Configuration for Analytics
 # Please refer to https://supabase.com/docs/reference/self-hosting-analytics/introduction
 ############
 
-LOGFLARE_LOGGER_BACKEND_API_KEY=your-super-secret-and-long-logflare-key
-
 # Change vector.toml sinks to reflect this change
-LOGFLARE_API_KEY=your-super-secret-and-long-logflare-key
+# these cannot be the same value
+LOGFLARE_PUBLIC_ACCESS_TOKEN=your-super-secret-and-long-logflare-key-public
+LOGFLARE_PRIVATE_ACCESS_TOKEN=your-super-secret-and-long-logflare-key-private
 
 # Docker socket location - this value will differ depending on your OS
 DOCKER_SOCKET_LOCATION=/var/run/docker.sock
@@ -115,3 +128,17 @@ DOCKER_SOCKET_LOCATION=/var/run/docker.sock
 # Google Cloud Project details
 GOOGLE_PROJECT_ID=GOOGLE_PROJECT_ID
 GOOGLE_PROJECT_NUMBER=GOOGLE_PROJECT_NUMBER
+
+############
+# Storage - Configuration for the storage
+############
+
+STORAGE_TENANT_ID=stub
+GLOBAL_S3_BUCKET=stub
+REGION=stub
+S3_PROTOCOL_ACCESS_KEY_ID=625729a08b95bf1b7ff351a663f3a23c
+S3_PROTOCOL_ACCESS_KEY_SECRET=850181e4652dd023b7a98c58ae0d2d34bd487ee0cc3254aed6eda37307425907
+
+# Used in docker-compose.s3.yml for minio
+MINIO_ROOT_USER=supa-storage
+MINIO_ROOT_PASSWORD=secret1234

--- a/src/Supabase.Faker/Supabase/dev/docker-compose.dev.yml
+++ b/src/Supabase.Faker/Supabase/dev/docker-compose.dev.yml
@@ -4,10 +4,20 @@ services:
   studio:
     build:
       context: ..
-      dockerfile: studio/Dockerfile
+      dockerfile: apps/studio/Dockerfile
       target: dev
     ports:
       - 8082:8082
+    develop:
+      watch:
+        - action: sync
+          path: ../apps/studio
+          target: /app/apps/studio
+          ignore:
+            - node_modules/
+        - action: rebuild
+          path: package.json
+
   mail:
     container_name: supabase-mail
     image: inbucket/inbucket:3.0.3

--- a/src/Supabase.Faker/Supabase/volumes/api/kong.yml
+++ b/src/Supabase.Faker/Supabase/volumes/api/kong.yml
@@ -27,8 +27,8 @@ acls:
 ###
 basicauth_credentials:
   - consumer: DASHBOARD
-    username: $DASHBOARD_USERNAME
-    password: $DASHBOARD_PASSWORD
+    username: '$DASHBOARD_USERNAME'
+    password: '$DASHBOARD_PASSWORD'
 
 ###
 ### API Routes
@@ -197,14 +197,29 @@ services:
       - name: cors
 
   ## Analytics routes
-  - name: analytics-v1
-    _comment: 'Analytics: /analytics/v1/* -> http://logflare:4000/*'
-    url: http://analytics:4000/
-    routes:
-      - name: analytics-v1-all
-        strip_path: true
-        paths:
-          - /analytics/v1/
+  ## Not used - Studio and Vector talk directly to analytics via Docker networking.
+  ## If external access is needed, add routes with key-auth matching Logflare's x-api-key auth.
+  # - name: analytics-v1-api
+  #   _comment: 'Analytics: /analytics/v1/api/endpoints/* -> http://logflare:4000/api/endpoints/*'
+  #   url: http://analytics:4000/api/endpoints
+  #   routes:
+  #     - name: analytics-v1-api
+  #       strip_path: true
+  #       paths:
+  #         - /analytics/v1/api/endpoints/
+  # - name: analytics-v1
+  #   _comment: 'Analytics: /analytics/v1/* -> http://logflare:4000/*'
+  #   url: http://analytics:4000/
+  #   routes:
+  #     - name: dashboard-v1-all
+  #       strip_path: true
+  #       paths:
+  #         - /analytics/v1
+  #   plugins:
+  #     - name: cors
+  #     - name: basic-auth
+  #       config:
+  #         hide_credentials: true
 
   ## Secure Database routes
   - name: meta
@@ -224,6 +239,48 @@ services:
           hide_groups_header: true
           allow:
             - admin
+
+  ## Block access to /api/mcp
+  - name: mcp-blocker
+    _comment: 'Block direct access to /api/mcp'
+    url: http://studio:3000/api/mcp
+    routes:
+      - name: mcp-blocker-route
+        strip_path: true
+        paths:
+          - /api/mcp
+    plugins:
+      - name: request-termination
+        config:
+          status_code: 403
+          message: "Access is forbidden."
+
+  ## MCP endpoint - local access
+  - name: mcp
+    _comment: 'MCP: /mcp -> http://studio:3000/api/mcp (local access)'
+    url: http://studio:3000/api/mcp
+    routes:
+      - name: mcp
+        strip_path: true
+        paths:
+          - /mcp
+    plugins:
+      # Block access to /mcp by default
+      - name: request-termination
+        config:
+          status_code: 403
+          message: "Access is forbidden."
+      # Enable local access (danger zone!)
+      # 1. Comment out the 'request-termination' section above
+      # 2. Uncomment the entire section below, including 'deny'
+      # 3. Add your local IPs to the 'allow' list
+      #- name: cors
+      #- name: ip-restriction
+      #  config:
+      #    allow:
+      #      - 127.0.0.1
+      #      - ::1
+      #    deny: []
 
   ## Protected Dashboard - catch all remaining routes
   - name: dashboard

--- a/src/Supabase.RPC.Tests/Supabase.RPC.Tests.csproj
+++ b/src/Supabase.RPC.Tests/Supabase.RPC.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/Supabase.RPC.Tests/TestFixture.cs
+++ b/src/Supabase.RPC.Tests/TestFixture.cs
@@ -64,8 +64,11 @@ public class TestFixture : IDisposable
     /// </summary>
     private async Task ExecuteRpcScripts()
     {
-        var connectionString =
-            _faker.Postgres.PostgresExternalConnectionString.Replace("supabase_auth_admin", "postgres");
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(_faker.Postgres.PostgresExternalConnectionString)
+        {
+            Username = "supabase_admin"
+        };
+        var connectionString = connectionStringBuilder.ConnectionString;
 
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync();

--- a/src/Supabase.RPC/Supabase.RPC.csproj
+++ b/src/Supabase.RPC/Supabase.RPC.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Authors>Hitmasu</Authors>


### PR DESCRIPTION
## Summary
- update Supabase Faker self-hosting envs to current keys/variables
- update dev compose and Kong config for current Supabase layout/plugins
- update container images and readiness strategy in `SupabaseFaker`
- bump `supabase-dotnet-faker` version from `1.1.0` to `1.2.0`

## Validation
- `dotnet build src/Supabase.Faker/Supabase.Faker.csproj -c Release`
