### PR TITLE
feat(auth)!: support string identity id for SSO providers

### DIFF
--- a/src/Supabase.Authentication/Auth/GoTrue/Responses/IdentityResponse.cs
+++ b/src/Supabase.Authentication/Auth/GoTrue/Responses/IdentityResponse.cs
@@ -5,7 +5,10 @@ namespace Supabase.Authentication.Auth.GoTrue.Responses;
 
 public class IdentityResponse<TCustomMetadata> where TCustomMetadata : UserMetadataBase
 {
-    public Guid Id { get; set; }
+    /// <summary>
+    /// Provider user identifier (for example, Google subject), not a UUID.
+    /// </summary>
+    public string Id { get; set; }
 
     [JsonPropertyName("identity_id")]
     public Guid IdentityId { get; set; }

--- a/src/Supabase.Authentication/Supabase.Authentication.csproj
+++ b/src/Supabase.Authentication/Supabase.Authentication.csproj
@@ -11,7 +11,7 @@
       <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
       <PackageLicenseExpression>MIT</PackageLicenseExpression>
       <PackageId>supabase-dotnet-authentication</PackageId>
-      <Version>1.3.2</Version>
+      <Version>2.0.0</Version>
       <RepositoryType>Git</RepositoryType>
       <PackageTags>Supabase</PackageTags>
     </PropertyGroup>


### PR DESCRIPTION
## Summary
- Changed `IdentityResponse<TCustomMetadata>.Id` from `Guid` to `string`.
- Added XML summary clarifying that provider identity IDs (for example Google subject) are not UUIDs.
- Bumped `supabase-dotnet-authentication` package version from `1.3.2` to `2.0.0`.

## Why
SSO providers return identity IDs as strings, not GUIDs. Keeping this field as `Guid` can cause parsing/runtime issues when provider IDs are non-UUID values.

## SemVer
This is a **breaking change** in the public API (`Id` type changed), so the major version was incremented.

## Validation
- `dotnet build src/Supabase.Authentication/Supabase.Authentication.csproj -c Release`
- `dotnet test src/Supabase.sln -c Release`
  - `Supabase.Authentication.Tests`: 38 passed
  - `Supabase.RPC.Tests`: 19 passed
