### PR TITLE
fix: release supabase-dotnet-faker 1.2.1 for containerized runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ services.AddSupabase("https://yourapiurlsupabase.co", "apikey");
 | Postgrest         | -              | 🏗️ In development |
 | Functions         | -              | 🏗️ In development |
 
+**Supabase Faker**
+-----------------
+
+For integration tests, `supabase-dotnet-faker` provisions a local Supabase stack with Testcontainers.
+
+As of `1.2.1`, the faker injects bootstrap SQL and Kong configuration files with Docker resource mappings instead of host bind mounts. This keeps the package working in containerized runners where the test process and the Docker daemon do not share the same `/tmp` filesystem view.
+
 **Authentication**
 -----------------
 

--- a/src/Supabase.Faker/Settings/BaseSettings.cs
+++ b/src/Supabase.Faker/Settings/BaseSettings.cs
@@ -2,10 +2,59 @@ namespace Supabase.Faker.Settings;
 
 public abstract class BaseSettings
 {
+    private static string? _cachedDockerHost;
+
     public BaseSettings(Dictionary<string, string> envVars)
     {
         EnvVars = envVars;
     }
 
     protected Dictionary<string, string> EnvVars { get; }
+
+    protected static string ResolveDockerHost(string fallbackHost)
+    {
+        var configuredHost = Environment.GetEnvironmentVariable("TESTCONTAINERS_HOST_OVERRIDE");
+        if (!string.IsNullOrWhiteSpace(configuredHost))
+            return configuredHost;
+
+        if (!string.Equals(fallbackHost, "localhost", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(fallbackHost, "127.0.0.1", StringComparison.OrdinalIgnoreCase))
+        {
+            return fallbackHost;
+        }
+
+        if (!string.IsNullOrWhiteSpace(_cachedDockerHost))
+            return _cachedDockerHost;
+
+        const string routePath = "/proc/net/route";
+        if (!File.Exists(routePath))
+            return fallbackHost;
+
+        try
+        {
+            foreach (var line in File.ReadAllLines(routePath).Skip(1))
+            {
+                var fields = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (fields.Length <= 2 || fields[1] != "00000000")
+                    continue;
+
+                var gatewayHex = fields[2];
+                if (gatewayHex.Length != 8)
+                    continue;
+
+                var octets = Enumerable.Range(0, 4)
+                    .Select(index => Convert.ToInt32(gatewayHex.Substring(6 - (index * 2), 2), 16))
+                    .ToArray();
+
+                _cachedDockerHost = string.Join('.', octets);
+                return _cachedDockerHost;
+            }
+        }
+        catch
+        {
+            return fallbackHost;
+        }
+
+        return fallbackHost;
+    }
 }

--- a/src/Supabase.Faker/Settings/PostgresSettings.cs
+++ b/src/Supabase.Faker/Settings/PostgresSettings.cs
@@ -32,7 +32,7 @@ public class PostgresSettings : BaseSettings
     /// <param name="isInternal"></param>
     /// <returns></returns>
     public string GetConnectionString(bool isInternal = false) =>
-        $"Host={(isInternal ? "supabase-db" : "localhost")};" +
+        $"Host={(isInternal ? "supabase-db" : ResolveDockerHost("localhost"))};" +
         $"Port={Port};" +
         $"Database={PostgresDatabase};" +
         $"Username={Username};" +

--- a/src/Supabase.Faker/Settings/RestSettings.cs
+++ b/src/Supabase.Faker/Settings/RestSettings.cs
@@ -18,7 +18,10 @@ public class RestSettings : BaseSettings
     /// The URI to connect to the REST API.
     /// </summary>
     public Uri Uri =>
-        new UriBuilder(Uri.UriSchemeHttp, _restContainer.Hostname, _restContainer.GetMappedPublicPort(3000)).Uri;
+        new UriBuilder(
+            Uri.UriSchemeHttp,
+            ResolveDockerHost(_restContainer.Hostname),
+            _restContainer.GetMappedPublicPort(3000)).Uri;
 
     /// <summary>
     /// The database schemas exposed by the REST API.

--- a/src/Supabase.Faker/Settings/SupabaseSettings.cs
+++ b/src/Supabase.Faker/Settings/SupabaseSettings.cs
@@ -12,7 +12,10 @@ public class SupabaseSettings : BaseSettings
     }
 
     public Uri Uri =>
-        new UriBuilder(Uri.UriSchemeHttp, _kongContainer.Hostname, _kongContainer.GetMappedPublicPort(8000)).Uri;
+        new UriBuilder(
+            Uri.UriSchemeHttp,
+            ResolveDockerHost(_kongContainer.Hostname),
+            _kongContainer.GetMappedPublicPort(8000)).Uri;
 
     public string ServiceRoleKey => EnvVars["SERVICE_ROLE_KEY"];
 }

--- a/src/Supabase.Faker/Supabase.Faker.csproj
+++ b/src/Supabase.Faker/Supabase.Faker.csproj
@@ -6,12 +6,12 @@
         <Nullable>enable</Nullable>
         <Authors>Hitmasu</Authors>
         <LangVersion>latest</LangVersion>
-        <Description>A client for Supabase Authentication.</Description>
+        <Description>Testcontainers-based Supabase stack for .NET integration tests.</Description>
         <RepositoryUrl>https://github.com/Hitmasu/supabase-dotnet</RepositoryUrl>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageId>supabase-dotnet-faker</PackageId>
-        <Version>1.2.0</Version>
+        <Version>1.2.1</Version>
         <RepositoryType>Git</RepositoryType>
         <PackageTags>Supabase</PackageTags>
     </PropertyGroup>

--- a/src/Supabase.Faker/SupabaseFaker.cs
+++ b/src/Supabase.Faker/SupabaseFaker.cs
@@ -56,6 +56,11 @@ public class SupabaseFaker : IAsyncLifetime
     {
         config ??= new FakerConfig();
         _suffix = shouldReuse ? string.Empty : $"-{Guid.NewGuid().ToString("N").Substring(0, 8)}";
+        var readableFileMode =
+            DotNet.Testcontainers.Configurations.UnixFileModes.UserRead |
+            DotNet.Testcontainers.Configurations.UnixFileModes.UserWrite |
+            DotNet.Testcontainers.Configurations.UnixFileModes.GroupRead |
+            DotNet.Testcontainers.Configurations.UnixFileModes.OtherRead;
 
         _dataPath = Path.Combine(Path.GetTempPath(), $"supabase-data{_suffix}");
         Directory.CreateDirectory(_dataPath);
@@ -83,16 +88,34 @@ public class SupabaseFaker : IAsyncLifetime
             .WithEnvironment("JWT_SECRET", _envVars["JWT_SECRET"])
             .WithEnvironment("JWT_EXPIRY", _envVars["JWT_EXPIRY"])
             .WithPortBinding(int.Parse(_envVars["POSTGRES_PORT"]), true)
-            .WithBindMount($"{_dataPath}/volumes/db/realtime.sql",
-                "/docker-entrypoint-initdb.d/migrations/99-realtime.sql")
-            .WithBindMount($"{_dataPath}/volumes/db/webhooks.sql",
-                "/docker-entrypoint-initdb.d/init-scripts/98-webhooks.sql")
-            .WithBindMount($"{_dataPath}/volumes/db/roles.sql", "/docker-entrypoint-initdb.d/init-scripts/99-roles.sql")
-            .WithBindMount($"{_dataPath}/volumes/db/jwt.sql", "/docker-entrypoint-initdb.d/init-scripts/99-jwt.sql")
-            .WithBindMount($"{_dataPath}/volumes/db/_supabase.sql",
-                "/docker-entrypoint-initdb.d/migrations/97-_supabase.sql")
-            .WithBindMount($"{_dataPath}/volumes/db/logs.sql", "/docker-entrypoint-initdb.d/migrations/99-logs.sql")
-            .WithBindMount($"{_dataPath}/volumes/db/pooler.sql", "/docker-entrypoint-initdb.d/migrations/99-pooler.sql")
+            .WithResourceMapping(
+                File.ReadAllBytes(Path.Combine(_dataPath, "volumes", "db", "realtime.sql")),
+                "/docker-entrypoint-initdb.d/migrations/99-realtime.sql",
+                readableFileMode)
+            .WithResourceMapping(
+                File.ReadAllBytes(Path.Combine(_dataPath, "volumes", "db", "webhooks.sql")),
+                "/docker-entrypoint-initdb.d/init-scripts/98-webhooks.sql",
+                readableFileMode)
+            .WithResourceMapping(
+                File.ReadAllBytes(Path.Combine(_dataPath, "volumes", "db", "roles.sql")),
+                "/docker-entrypoint-initdb.d/init-scripts/99-roles.sql",
+                readableFileMode)
+            .WithResourceMapping(
+                File.ReadAllBytes(Path.Combine(_dataPath, "volumes", "db", "jwt.sql")),
+                "/docker-entrypoint-initdb.d/init-scripts/99-jwt.sql",
+                readableFileMode)
+            .WithResourceMapping(
+                File.ReadAllBytes(Path.Combine(_dataPath, "volumes", "db", "_supabase.sql")),
+                "/docker-entrypoint-initdb.d/migrations/97-_supabase.sql",
+                readableFileMode)
+            .WithResourceMapping(
+                File.ReadAllBytes(Path.Combine(_dataPath, "volumes", "db", "logs.sql")),
+                "/docker-entrypoint-initdb.d/migrations/99-logs.sql",
+                readableFileMode)
+            .WithResourceMapping(
+                File.ReadAllBytes(Path.Combine(_dataPath, "volumes", "db", "pooler.sql")),
+                "/docker-entrypoint-initdb.d/migrations/99-pooler.sql",
+                readableFileMode)
             .WithWaitStrategy(Wait.ForUnixContainer()
                 .UntilCommandIsCompleted("pg_isready", "-U", "postgres", "-h", "localhost"))
             .Build();
@@ -178,7 +201,10 @@ public class SupabaseFaker : IAsyncLifetime
             .WithEnvironment("DASHBOARD_PASSWORD", _envVars["DASHBOARD_PASSWORD"])
             .WithPortBinding(int.Parse(_envVars["KONG_HTTP_PORT"]), true)
             .WithPortBinding(int.Parse(_envVars["KONG_HTTPS_PORT"]), true)
-            .WithBindMount($"{_dataPath}/volumes/api/kong.yml", "/home/kong/temp.yml")
+            .WithResourceMapping(
+                File.ReadAllBytes(Path.Combine(_dataPath, "volumes", "api", "kong.yml")),
+                "/home/kong/temp.yml",
+                readableFileMode)
             .WithEntrypoint("/bin/bash", "-c", @"
                 cp /home/kong/temp.yml /home/kong/kong.yml && \
                 sed -i 's|\$SUPABASE_ANON_KEY|'$SUPABASE_ANON_KEY'|g; \


### PR DESCRIPTION
## Summary
- replace faker host bind mounts with Docker resource mappings for SQL bootstrap and Kong config
- resolve external container hosts via TESTCONTAINERS_HOST_OVERRIDE or the default Docker gateway
- bump `supabase-dotnet-faker` to `1.2.1` and document the containerized runner behavior in the README

## Validation
- `dotnet build src/Supabase.Faker/Supabase.Faker.csproj -c Release`
- `bash scripts/run-harness.sh` in `Naeko.Identity` consuming the corrected faker source
